### PR TITLE
feat(server): FLUSH_MODE=pull-request routes every flush through a reusable PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
-      - run: bun test
+      # Build first: intra-workspace deps resolve to workspace packages,
+      # whose exports point at dist/.
       - run: bun run build:packages
+      - run: bun test
       - run: bun run typecheck
       - run: bun run --filter '@quiescent/web' build

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
       "name": "@quiescent/server",
       "version": "0.2.0",
       "dependencies": {
-        "@quiescent/git": "^0.1.0",
+        "@quiescent/git": "^0.2.0",
       },
       "devDependencies": {
         "@types/bun": "^1.2.0",
@@ -982,8 +982,6 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@astrojs/cloudflare/wrangler": ["wrangler@4.59.2", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.10.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.0", "miniflare": "4.20260114.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260114.0" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260114.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-Z4xn6jFZTaugcOKz42xvRAYKgkVUERHVbuCJ5+f+gK+R6k12L02unakPGOA0L0ejhUl16dqDjKe4tmL9sedHcw=="],
-
-    "@quiescent/server/@quiescent/git": ["@quiescent/git@0.1.0", "", {}, "sha512-HCrxn3Q704y25F1dv23HjqKS2yI1B/SLi15B6S8meWRi07e7mRor2uv5gqguBVSJPogxNmhLsb68iLvRgyphpQ=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 

--- a/code/git/src/gitea.ts
+++ b/code/git/src/gitea.ts
@@ -146,6 +146,14 @@ export class GiteaForge implements ForgeClient {
     });
   }
 
+  async resetBranch(name: string, sha: string): Promise<void> {
+    // Gitea has no force-update-ref endpoint; recreate the branch at the sha.
+    await this.http.request(`${this.repoPath}/branches/${encodePath(name)}`, {
+      method: "DELETE",
+    });
+    await this.createBranch(name, sha);
+  }
+
   async createPullRequest(options: CreatePullRequestOptions): Promise<PullRequest> {
     const pull = await this.http.json<{ number: number; html_url: string }>(
       `${this.repoPath}/pulls`,
@@ -160,6 +168,29 @@ export class GiteaForge implements ForgeClient {
       },
     );
     return { number: pull.number, url: pull.html_url };
+  }
+
+  async findOpenPullRequest(head: string, base: string): Promise<PullRequest | null> {
+    // Gitea's list endpoint has no head filter; match on the head label
+    // ("owner:branch" for cross-repo heads, plain branch otherwise).
+    const [headOwner, headBranch] = head.includes(":")
+      ? (head.split(":", 2) as [string, string])
+      : [this.config.owner, head];
+    const pulls = await this.http.json<
+      {
+        number: number;
+        html_url: string;
+        base: { ref: string };
+        head: { ref: string; repo?: { owner?: { login?: string } } };
+      }[]
+    >(`${this.repoPath}/pulls?state=open&limit=50`);
+    const pull = pulls.find(
+      (p) =>
+        p.base.ref === base &&
+        p.head.ref === headBranch &&
+        (p.head.repo?.owner?.login ?? this.config.owner) === headOwner,
+    );
+    return pull ? { number: pull.number, url: pull.html_url } : null;
   }
 
   async ensureFork(): Promise<{ owner: string; repo: string }> {

--- a/code/git/src/github.ts
+++ b/code/git/src/github.ts
@@ -150,6 +150,13 @@ export class GitHubForge implements ForgeClient {
     });
   }
 
+  async resetBranch(name: string, sha: string): Promise<void> {
+    await this.http.json(`${this.repoPath}/git/refs/heads/${encodePath(name)}`, {
+      method: "PATCH",
+      body: JSON.stringify({ sha, force: true }),
+    });
+  }
+
   async createPullRequest(options: CreatePullRequestOptions): Promise<PullRequest> {
     const pull = await this.http.json<{ number: number; html_url: string }>(
       `${this.repoPath}/pulls`,
@@ -164,6 +171,16 @@ export class GitHubForge implements ForgeClient {
       },
     );
     return { number: pull.number, url: pull.html_url };
+  }
+
+  async findOpenPullRequest(head: string, base: string): Promise<PullRequest | null> {
+    // GitHub's head filter requires the owner-qualified form.
+    const qualified = head.includes(":") ? head : `${this.config.owner}:${head}`;
+    const pulls = await this.http.json<{ number: number; html_url: string }[]>(
+      `${this.repoPath}/pulls?state=open&head=${encodeURIComponent(qualified)}&base=${encodeURIComponent(base)}`,
+    );
+    const pull = pulls[0];
+    return pull ? { number: pull.number, url: pull.html_url } : null;
   }
 
   async ensureFork(): Promise<{ owner: string; repo: string }> {

--- a/code/git/src/types.ts
+++ b/code/git/src/types.ts
@@ -81,7 +81,14 @@ export interface ForgeClient {
   getBranchSha(branch: string): Promise<string>;
   commitFiles(options: CommitFilesOptions): Promise<CommitResult>;
   createBranch(name: string, fromSha: string): Promise<void>;
+  /** Force-moves an existing branch head to the given sha. */
+  resetBranch(name: string, sha: string): Promise<void>;
   createPullRequest(options: CreatePullRequestOptions): Promise<PullRequest>;
+  /**
+   * Finds the open pull request from the given head (same "branch" or
+   * "owner:branch" convention as CreatePullRequestOptions) into base, or null.
+   */
+  findOpenPullRequest(head: string, base: string): Promise<PullRequest | null>;
   /** Fork the repo for contributors without push access. Returns the fork's owner/repo. */
   ensureFork(): Promise<{ owner: string; repo: string }>;
 }

--- a/code/git/test/gitea.test.ts
+++ b/code/git/test/gitea.test.ts
@@ -72,6 +72,35 @@ describe("GiteaForge", () => {
     await client.createBranch("suggest-1", "head1");
     expect(requests[0]?.body).toEqual({ new_branch_name: "suggest-1", old_ref_name: "head1" });
   });
+
+  test("resetBranch deletes then recreates the branch", async () => {
+    const { client, requests } = forge([
+      { method: "DELETE", url: "/branches/quiescent/ncrmro", response: {} },
+      { method: "POST", url: "/branches", response: {} },
+    ]);
+    await client.resetBranch("quiescent/ncrmro", "base1");
+    expect(requests.map((r) => r.method)).toEqual(["DELETE", "POST"]);
+    expect(requests[1]?.body).toEqual({ new_branch_name: "quiescent/ncrmro", old_ref_name: "base1" });
+  });
+
+  test("findOpenPullRequest matches head ref, owner, and base", async () => {
+    const pulls = [
+      { number: 1, html_url: "http://pr1", base: { ref: "main" }, head: { ref: "other" } },
+      {
+        number: 2,
+        html_url: "http://pr2",
+        base: { ref: "main" },
+        head: { ref: "quiescent/ncrmro", repo: { owner: { login: "ncrmro" } } },
+      },
+    ];
+    const { client } = forge([{ method: "GET", url: "/pulls?state=open", response: pulls }]);
+    expect(await client.findOpenPullRequest("quiescent/ncrmro", "main")).toEqual({
+      number: 2,
+      url: "http://pr2",
+    });
+    expect(await client.findOpenPullRequest("someone-else:quiescent/ncrmro", "main")).toBeNull();
+    expect(await client.findOpenPullRequest("quiescent/ncrmro", "develop")).toBeNull();
+  });
 });
 
 describe("base64", () => {

--- a/code/git/test/github.test.ts
+++ b/code/git/test/github.test.ts
@@ -107,4 +107,28 @@ describe("GitHubForge", () => {
     expect(pr).toEqual({ number: 7, url: "http://pr" });
     expect(requests[0]?.body).toEqual({ ref: "refs/heads/quiescent/ncrmro/1", sha: "head1" });
   });
+
+  test("resetBranch force-updates the ref", async () => {
+    const { client, requests } = forge([
+      { method: "PATCH", url: "/git/refs/heads/quiescent/ncrmro", response: {} },
+    ]);
+    await client.resetBranch("quiescent/ncrmro", "base1");
+    expect(requests[0]?.body).toEqual({ sha: "base1", force: true });
+  });
+
+  test("findOpenPullRequest owner-qualifies bare heads and returns first match or null", async () => {
+    const { client, requests } = forge([
+      { method: "GET", url: "/pulls?state=open", response: [{ number: 3, html_url: "http://pr3" }] },
+    ]);
+    expect(await client.findOpenPullRequest("quiescent/ncrmro", "main")).toEqual({
+      number: 3,
+      url: "http://pr3",
+    });
+    expect(requests[0]?.url).toContain(
+      `head=${encodeURIComponent("ncrmro:quiescent/ncrmro")}&base=main`,
+    );
+
+    const { client: empty } = forge([{ method: "GET", url: "/pulls?state=open", response: [] }]);
+    expect(await empty.findOpenPullRequest("fork-owner:quiescent/x", "main")).toBeNull();
+  });
 });

--- a/code/server/package.json
+++ b/code/server/package.json
@@ -29,7 +29,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@quiescent/git": "^0.1.0"
+    "@quiescent/git": "^0.2.0"
   },
   "devDependencies": {
     "@types/bun": "^1.2.0",

--- a/code/server/src/env.ts
+++ b/code/server/src/env.ts
@@ -18,7 +18,14 @@ export interface Env {
   OAUTH_CLIENT_SECRET: string;
   /** Where the app mounts its OAuth callback route; defaults to /auth/callback. */
   OAUTH_CALLBACK_PATH?: string;
+  /**
+   * "pull-request" routes every flush through a pull request, even for users
+   * with push access; unset/"auto" keeps notes mode (direct commit) for them.
+   */
+  FLUSH_MODE?: "auto" | "pull-request";
   SESSION_SECRET: string;
+  /** Injectable for tests. */
+  fetch?: typeof fetch;
 }
 
 export function forgeConfig(env: Env, token: string): ForgeConfig {
@@ -28,6 +35,7 @@ export function forgeConfig(env: Env, token: string): ForgeConfig {
     owner: env.REPO_OWNER,
     repo: env.REPO_NAME,
     token,
+    fetch: env.fetch,
   };
 }
 

--- a/code/server/src/flush.ts
+++ b/code/server/src/flush.ts
@@ -40,7 +40,7 @@ export async function flushDrafts(options: {
   const message = commitMessage(files);
 
   let result: FlushResult;
-  if (session.canPush) {
+  if (session.canPush && env.FLUSH_MODE !== "pull-request") {
     const commit = await forge.commitFiles({
       branch: env.DEFAULT_BRANCH,
       message,
@@ -63,19 +63,28 @@ async function proposeViaPullRequest(
   files: CommitFileChange[],
   message: string,
 ): Promise<FlushResult> {
-  const branch = `quiescent/${session.login}/${Date.now()}`;
+  // One stable branch per user: repeated flushes stack commits onto the same
+  // open pull request instead of spawning a branch + PR (and a CI run per PR)
+  // every time.
+  const branch = `quiescent/${session.login}`;
   const title = `Suggested edits from ${session.login}`;
   const body = `Proposed via [quiescent](https://github.com/ncrmro/quiescent).\n\n${files
     .map((f) => `- \`${f.path}\``)
     .join("\n")}`;
-  const baseSha = await forge.getBranchSha(env.DEFAULT_BRANCH);
 
   try {
     // Some repos allow contributors to push branches directly.
-    await forge.createBranch(branch, baseSha);
-    await forge.commitFiles({ branch, message, files });
-    const pr = await forge.createPullRequest({ head: branch, base: env.DEFAULT_BRANCH, title, body });
-    return { mode: "pull-request", url: pr.url, paths: files.map((f) => f.path) };
+    return await flushToBranchPullRequest({
+      env,
+      prForge: forge,
+      commitForge: forge,
+      head: branch,
+      branch,
+      files,
+      message,
+      title,
+      body,
+    });
   } catch (error) {
     if (!(error instanceof ForgeError) || (error.status !== 403 && error.status !== 404)) {
       throw error;
@@ -85,16 +94,62 @@ async function proposeViaPullRequest(
   // No branch permission: fork, commit there, open a cross-repo PR.
   const fork = await forge.ensureFork();
   const forkForge = createForge({ ...forgeConfig(env, token), owner: fork.owner, repo: fork.repo });
-  const forkBaseSha = await forkForge.getBranchSha(env.DEFAULT_BRANCH);
-  await forkForge.createBranch(branch, forkBaseSha);
-  await forkForge.commitFiles({ branch, message, files });
-  const pr = await forge.createPullRequest({
+  return flushToBranchPullRequest({
+    env,
+    prForge: forge,
+    commitForge: forkForge,
     head: `${fork.owner}:${branch}`,
-    base: env.DEFAULT_BRANCH,
+    branch,
+    files,
+    message,
     title,
     body,
   });
-  return { mode: "pull-request", url: pr.url, paths: files.map((f) => f.path) };
+}
+
+/**
+ * Commits onto the user's quiescent branch, reusing the open pull request for
+ * it when one exists; otherwise points the branch at the current base head
+ * (creating or resetting it) and opens a fresh pull request.
+ */
+async function flushToBranchPullRequest(options: {
+  env: Env;
+  /** Upstream repo: where pull requests live. */
+  prForge: ForgeClient;
+  /** Where the branch and commits go — upstream, or the user's fork. */
+  commitForge: ForgeClient;
+  head: string;
+  branch: string;
+  files: CommitFileChange[];
+  message: string;
+  title: string;
+  body: string;
+}): Promise<FlushResult> {
+  const { env, prForge, commitForge, head, branch, files, message, title, body } = options;
+  const paths = files.map((f) => f.path);
+
+  const existing = await prForge.findOpenPullRequest(head, env.DEFAULT_BRANCH);
+  if (existing) {
+    await commitForge.commitFiles({ branch, message, files });
+    return { mode: "pull-request", url: existing.url, paths };
+  }
+
+  // No open PR: any commits left on the branch belong to a merged or closed
+  // PR, so (re)point it at the base head before committing.
+  const baseSha = await commitForge.getBranchSha(env.DEFAULT_BRANCH);
+  let branchSha: string | null;
+  try {
+    branchSha = await commitForge.getBranchSha(branch);
+  } catch (error) {
+    if (error instanceof ForgeError && error.status === 404) branchSha = null;
+    else throw error;
+  }
+  if (branchSha === null) await commitForge.createBranch(branch, baseSha);
+  else if (branchSha !== baseSha) await commitForge.resetBranch(branch, baseSha);
+
+  await commitForge.commitFiles({ branch, message, files });
+  const pr = await prForge.createPullRequest({ head, base: env.DEFAULT_BRANCH, title, body });
+  return { mode: "pull-request", url: pr.url, paths };
 }
 
 /**

--- a/code/server/test/flush.test.ts
+++ b/code/server/test/flush.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+import { saveDraft, getDraft, type Draft } from "../src/drafts.ts";
+import type { Env } from "../src/env.ts";
+import { flushDrafts } from "../src/flush.ts";
+import { createMemoryStore } from "../src/kv.ts";
+import type { Session } from "../src/session.ts";
+
+interface RecordedRequest {
+  method: string;
+  url: string;
+  body?: unknown;
+}
+
+interface Route {
+  method: string;
+  /** Matched against the full URL with String.includes. */
+  url: string;
+  status?: number;
+  response: unknown;
+}
+
+function createMockFetch(routes: Route[]) {
+  const requests: RecordedRequest[] = [];
+  const mockFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const method = init?.method ?? "GET";
+    requests.push({ method, url, body: init?.body ? JSON.parse(init.body as string) : undefined });
+    const route = routes.find((r) => r.method === method && url.includes(r.url));
+    if (!route) {
+      return new Response(JSON.stringify({ message: "no mock route" }), { status: 404 });
+    }
+    return new Response(JSON.stringify(route.response), {
+      status: route.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  return { mockFetch, requests };
+}
+
+function makeEnv(routes: Route[], overrides: Partial<Env> = {}) {
+  const { mockFetch, requests } = createMockFetch(routes);
+  const env: Env = {
+    SESSIONS: createMemoryStore(),
+    DRAFTS: createMemoryStore(),
+    FORGE_KIND: "github",
+    REPO_OWNER: "ncrmro",
+    REPO_NAME: "website",
+    DEFAULT_BRANCH: "main",
+    OAUTH_CLIENT_ID: "id",
+    OAUTH_CLIENT_SECRET: "secret",
+    SESSION_SECRET: "s3cret",
+    fetch: mockFetch,
+    ...overrides,
+  };
+  return { env, requests };
+}
+
+const session: Session = {
+  userId: 1,
+  login: "ncrmro",
+  canPush: true,
+  tokens: { accessToken: "gho_test" },
+};
+
+const draft: Draft = {
+  userId: 1,
+  sessionId: "sess-1",
+  path: "code/web/src/content/blog/post.mdx",
+  content: "# hi",
+  updatedAt: Date.now(),
+};
+
+// Shared GitHub mock routes for the commit sequence on the quiescent branch.
+const commitRoutes: Route[] = [
+  { method: "GET", url: "/git/commits/", response: { tree: { sha: "tree0" } } },
+  { method: "POST", url: "/git/trees", response: { sha: "tree1" } },
+  { method: "POST", url: "/git/commits", response: { sha: "commit1", html_url: "http://c1" } },
+  { method: "PATCH", url: "/git/refs/heads/quiescent/ncrmro", response: {} },
+];
+
+describe("flushDrafts", () => {
+  test("default mode commits straight to the default branch for push users", async () => {
+    const { env, requests } = makeEnv([
+      { method: "GET", url: "/git/ref/heads/main", response: { object: { sha: "head1" } } },
+      { method: "GET", url: "/git/commits/head1", response: { tree: { sha: "tree0" } } },
+      { method: "POST", url: "/git/trees", response: { sha: "tree1" } },
+      { method: "POST", url: "/git/commits", response: { sha: "commit1", html_url: "http://c1" } },
+      { method: "PATCH", url: "/git/refs/heads/main", response: {} },
+    ]);
+    await saveDraft(env, draft);
+
+    const result = await flushDrafts({
+      env,
+      origin: "https://example.com",
+      sessionId: "sess-1",
+      session,
+      drafts: [draft],
+    });
+
+    expect(result).toEqual({ mode: "commit", url: "http://c1", sha: "commit1", paths: [draft.path] });
+    expect(requests.some((r) => r.method === "POST" && r.url.includes("/pulls"))).toBe(false);
+    expect(await getDraft(env, draft.userId, draft.path)).toBeNull();
+  });
+
+  test("FLUSH_MODE=pull-request opens a PR from the stable quiescent branch, never touching main", async () => {
+    const { env, requests } = makeEnv(
+      [
+        { method: "GET", url: "/pulls?state=open", response: [] },
+        { method: "GET", url: "/git/ref/heads/main", response: { object: { sha: "base1" } } },
+        // quiescent/ncrmro exists but points at a stale (merged) sha.
+        { method: "GET", url: "/git/ref/heads/quiescent/ncrmro", response: { object: { sha: "stale1" } } },
+        ...commitRoutes,
+        { method: "POST", url: "/pulls", response: { number: 9, html_url: "http://pr9" } },
+      ],
+      { FLUSH_MODE: "pull-request" },
+    );
+    await saveDraft(env, draft);
+
+    const result = await flushDrafts({
+      env,
+      origin: "https://example.com",
+      sessionId: "sess-1",
+      session,
+      drafts: [draft],
+    });
+
+    expect(result).toEqual({ mode: "pull-request", url: "http://pr9", paths: [draft.path] });
+    // Stale branch was force-reset onto main's head before committing.
+    const reset = requests.find(
+      (r) => r.method === "PATCH" && r.url.includes("/git/refs/heads/quiescent/ncrmro"),
+    );
+    expect(reset?.body).toMatchObject({ sha: "base1", force: true });
+    // Nothing was committed to main.
+    expect(requests.some((r) => r.method === "PATCH" && r.url.includes("/git/refs/heads/main"))).toBe(false);
+    expect(await getDraft(env, draft.userId, draft.path)).toBeNull();
+  });
+
+  test("reuses the open pull request instead of opening a new one per flush", async () => {
+    const { env, requests } = makeEnv(
+      [
+        {
+          method: "GET",
+          url: "/pulls?state=open",
+          response: [{ number: 9, html_url: "http://pr9" }],
+        },
+        { method: "GET", url: "/git/ref/heads/quiescent/ncrmro", response: { object: { sha: "head1" } } },
+        ...commitRoutes,
+      ],
+      { FLUSH_MODE: "pull-request" },
+    );
+    await saveDraft(env, draft);
+
+    const result = await flushDrafts({
+      env,
+      origin: "https://example.com",
+      sessionId: "sess-1",
+      session,
+      drafts: [draft],
+    });
+
+    expect(result).toEqual({ mode: "pull-request", url: "http://pr9", paths: [draft.path] });
+    expect(requests.some((r) => r.method === "POST" && r.url.includes("/pulls"))).toBe(false);
+    expect(requests.some((r) => r.method === "POST" && r.url.includes("/git/refs"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `FLUSH_MODE=pull-request` (new `Env` var) routes **every** flush through a pull request, even for users with push access — unset/`auto` keeps notes mode (direct commit to the default branch).
- The PR path now uses one stable branch per user (`quiescent/<login>`) and reuses its open PR: repeated flushes stack commits onto the same PR instead of minting a timestamped branch + new PR (and a CI run per PR) each time. When no PR is open (previous one merged/closed), the branch is reset onto the base head before committing.
- `@quiescent/git`: `ForgeClient` gains `resetBranch` (force ref update on GitHub; delete + recreate on Gitea) and `findOpenPullRequest` — implemented for both forges. The fork fallback for contributors without branch permission keeps working, with the same stable-branch reuse.
- `@quiescent/server`: optional injectable `fetch` on `Env` so `flushDrafts` is testable end-to-end; intra-workspace dep bumped to `^0.2.0` so the workspace copy actually links during dev (0.x caret semantics silently pulled the stale 0.1.0 registry package).

Motivation: ncrmro/website#88 wires quiescent up to publish posts, but drafts should land as reviewable PRs, not direct commits to `main` — and idle-flush + cron must not spam PRs/CI.

## Test plan
- [x] `bun test` — 30 pass, incl. new end-to-end `flushDrafts` tests (direct-commit default, forced PR with stale-branch reset, open-PR reuse) and forge-method tests for GitHub/Gitea
- [x] `bun run build:packages`, `bun run typecheck`, `@quiescent/web` build

🤖 Generated with [Claude Code](https://claude.com/claude-code)